### PR TITLE
Add example for querying SRA metadata in S3 with DuckDB

### DIFF
--- a/SRA_list.md
+++ b/SRA_list.md
@@ -14,7 +14,7 @@ Then, type this command:
     awk -F',' '$4 == "\"9606\"" { print }' \
     > list_accessions_human.txt
 
-What this does, is stream a file from the Logan bucket that contains a list of all SRA accessions in Logan, along with some metadata extracted from the SRA (library type, species name, species tax ID, I forgot the last two fields). For other species, change 9606 in the command to the correct `tax_id`.
+What this does, is stream a file from the Logan bucket that contains a list of all SRA accessions in Logan, along with some metadata extracted from the SRA (library type, organism name, organism tax ID, taxon rank, I forgot the last field). For other species, change 9606 in the command to the correct `tax_id`.
 
 This gives you a list of SRA accessions that are annotated as belonging to that species. But of course, not all Logan contigs of those accession will be from that species, e.g. think of the contaminating viruses, bacteria, etc..
 

--- a/SRA_list.md
+++ b/SRA_list.md
@@ -34,17 +34,17 @@ Then, same principle as the previous method: if you have a species name of inter
 
 It will grab the list of accessions where there are sufficiently many reads from that species, and for each accession you have the `total_count` field, which very roughly approximates the number of reads from that accession corresponding to the species (but think of it as a subsampled number).
 
-As an alternative to Amazon Athena or Google BigQuery, you can use [DuckDB](https://duckdb.org/) to query SRA metadata stored as Parquet files in the cloud. This approach is simpler, as it does not require an account with a cloud provider, but it provides access to a more limited set of metadata compared to Athena and BigQuery.
+As an alternative to Amazon Athena or Google BigQuery, you can use [DuckDB](https://duckdb.org/) to query SRA metadata stored as Parquet files in the cloud. This approach is simpler, as it does not require an account with a cloud provider, but it only provides the basic SRA metadata table and doesn't allow access to the taxonomy analysis table used in the example above.
 
-  duckdb -c "
-  INSTALL httpfs;
-  LOAD httpfs;
-  INSTALL parquet;
-  LOAD parquet;
-  COPY (
-    SELECT *
-    FROM read_parquet('s3://sra-pub-metadata-us-east-1/sra/metadata/*')
-    WHERE releasedate > '2021-09-07' AND geo_loc_name_country_calc = 'Brazil'
-  ) TO STDOUT WITH (FORMAT CSV, DELIMITER E'\t', HEADER);"
+    duckdb -c "
+    INSTALL httpfs;
+    LOAD httpfs;
+    INSTALL parquet;
+    LOAD parquet;
+    COPY (
+      SELECT *
+      FROM read_parquet('s3://sra-pub-metadata-us-east-1/sra/metadata/*')
+      WHERE releasedate > '2021-09-07' AND geo_loc_name_country_calc = 'Brazil'
+    ) TO STDOUT WITH (FORMAT CSV, DELIMITER E'\t', HEADER);"
 
 The query above retrieves accessions released after 7 September 2021, where the associated samples were collected in Brazil.

--- a/SRA_list.md
+++ b/SRA_list.md
@@ -34,7 +34,7 @@ Then, same principle as the previous method: if you have a species name of inter
 
 It will grab the list of accessions where there are sufficiently many reads from that species, and for each accession you have the `total_count` field, which very roughly approximates the number of reads from that accession corresponding to the species (but think of it as a subsampled number).
 
-As an alternative to Amazon Athena or Google BigQuery, you can use [DuckDB](https://duckdb.org/) to query SRA metadata stored as Parquet files in the cloud. This approach is simpler, as it does not require an account with a cloud provider, but it only provides the basic SRA metadata table and doesn't allow access to the taxonomy analysis table used in the example above.
+As an alternative to Amazon Athena or Google BigQuery, you can use [DuckDB](https://duckdb.org/) to query SRA metadata stored as Parquet files in the cloud. This approach is simpler, as it does not require an account with a cloud provider, but it only provides the basic SRA metadata table and doesn't allow access to the taxonomy analysis table used in the example above (see the list of available columns [here](https://www.ncbi.nlm.nih.gov/sra/docs/sra-cloud-based-metadata-table/)).
 
     duckdb -c "
     INSTALL httpfs;


### PR DESCRIPTION
SRA metadata is available in S3 (although this is poorly documented) and can be easily retrieved from there. This PR adds an example to the `SRA_list.md` guide illustrating how to query this data using DuckDB.